### PR TITLE
Fix over-qualified reference to GzipFile

### DIFF
--- a/python/example1/example1.py
+++ b/python/example1/example1.py
@@ -56,7 +56,7 @@ else:
 if compression:
    if sys.version_info[0] >= 3:
       from gzip import GzipFile
-      file = gzip.GzipFile(fileobj = ssl_sock.makefile('rb'), mode = 'r')
+      file = GzipFile(fileobj = ssl_sock.makefile('rb'), mode = 'r')
    else:
       # compression mode on Python 2 requires GzipStream handler from:
       # https://fedorahosted.org/spacewalk/wiki/Projects/python-gzipstream


### PR DESCRIPTION
Attempting to enable compression under python 3 otherwise fails with:

```
Traceback (most recent call last):
  File "./python/example1/example1.py", line 59, in <module>
    file = gzip.GzipFile(fileobj = ssl_sock.makefile('rb'), mode = 'r')
NameError: name 'gzip' is not defined
```